### PR TITLE
feat: add packet-based player mines

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,10 @@
             <id>sqlite</id>
             <url>https://oss.sonatype.org/content/repositories/releases/org/xerial/sqlite-jdbc/</url>
         </repository>
+        <repository>
+            <id>dmulloy2-repo</id>
+            <url>https://repo.dmulloy2.net/nexus/repository/public/</url>
+        </repository>
     </repositories>
 
     <properties>
@@ -212,6 +216,12 @@
         <dependency>
             <groupId>com.github.MilkBowl</groupId>
             <artifactId>VaultAPI</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.comphenix.protocol</groupId>
+            <artifactId>ProtocolLib</artifactId>
+            <version>5.2.0</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/src/main/java/dev/drawethree/xprison/mines/XPrisonMines.java
+++ b/src/main/java/dev/drawethree/xprison/mines/XPrisonMines.java
@@ -7,6 +7,8 @@ import dev.drawethree.xprison.mines.commands.MineCommand;
 import dev.drawethree.xprison.mines.commands.impl.*;
 import dev.drawethree.xprison.mines.listener.MinesListener;
 import dev.drawethree.xprison.mines.managers.MineManager;
+import dev.drawethree.xprison.mines.packet.PacketMineManager;
+import dev.drawethree.xprison.mines.packet.PacketMineListener;
 import dev.drawethree.xprison.utils.player.PlayerUtils;
 import dev.drawethree.xprison.utils.text.TextUtils;
 import lombok.Getter;
@@ -30,7 +32,9 @@ public class XPrisonMines extends XPrisonModuleBase {
 	@Getter
 	private FileManager.Config config;
 	@Getter
-	private MineManager manager;
+        private MineManager manager;
+        @Getter
+        private PacketMineManager packetManager;
 
 	private Map<String, MineCommand> commands;
 
@@ -45,10 +49,12 @@ public class XPrisonMines extends XPrisonModuleBase {
 		super.enable();
 		this.config = this.core.getFileManager().getConfig("mines.yml").copyDefaults(true).save();
 		this.loadMessages();
-		this.manager = new MineManager(this);
-		this.manager.enable();
-		new MinesListener(this).register();
-		this.registerCommands();
+                this.manager = new MineManager(this);
+                this.manager.enable();
+                this.packetManager = new PacketMineManager(this);
+                new PacketMineListener(this.packetManager);
+                new MinesListener(this).register();
+                this.registerCommands();
 		this.enabled = true;
 	}
 
@@ -105,10 +111,10 @@ public class XPrisonMines extends XPrisonModuleBase {
 		Commands.create()
 				.handler(c -> {
 
-					if (c.args().isEmpty() && c.sender() instanceof Player) {
-						this.getCommand("help").execute(c.sender(), c.args());
-						return;
-					}
+                if (c.args().isEmpty() && c.sender() instanceof Player) {
+                        this.packetManager.openMainGUI((Player) c.sender());
+                        return;
+                }
 
 					MineCommand subCommand = this.getCommand(Objects.requireNonNull(c.rawArg(0)));
 

--- a/src/main/java/dev/drawethree/xprison/mines/packet/PacketMine.java
+++ b/src/main/java/dev/drawethree/xprison/mines/packet/PacketMine.java
@@ -1,0 +1,116 @@
+package dev.drawethree.xprison.mines.packet;
+
+import com.comphenix.protocol.PacketType;
+import com.comphenix.protocol.ProtocolLibrary;
+import com.comphenix.protocol.ProtocolManager;
+import com.comphenix.protocol.events.PacketContainer;
+import com.comphenix.protocol.wrappers.BlockPosition;
+import com.comphenix.protocol.wrappers.WrappedBlockData;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.UUID;
+
+/**
+ * Represents a player's personal mine rendered client side using packets.
+ */
+public class PacketMine {
+
+    private final UUID owner;
+    private final int size;
+    private final int height = 64;
+    private final Location origin;
+    private final Set<BlockPosition> brokenBlocks = new HashSet<>();
+    private final Material blockMaterial = Material.STONE;
+
+    public PacketMine(UUID owner, Location origin, int size) {
+        this.owner = owner;
+        this.origin = origin;
+        this.size = size;
+    }
+
+    public UUID getOwner() {
+        return owner;
+    }
+
+    public int getSize() {
+        return size;
+    }
+
+    public Location getOrigin() {
+        return origin;
+    }
+
+    private ProtocolManager protocol() {
+        return ProtocolLibrary.getProtocolManager();
+    }
+
+    /**
+     * Sends packets to the player rendering the full mine.
+     */
+    public void render(Player player) {
+        ProtocolManager pm = protocol();
+        for (int x = 0; x < size; x++) {
+            for (int z = 0; z < size; z++) {
+                for (int y = 0; y < height; y++) {
+                    BlockPosition bp = new BlockPosition(
+                            origin.getBlockX() + x,
+                            origin.getBlockY() + y,
+                            origin.getBlockZ() + z);
+                    PacketContainer packet = pm.createPacket(PacketType.Play.Server.BLOCK_CHANGE);
+                    packet.getBlockPositionModifier().write(0, bp);
+                    packet.getBlockData().write(0, WrappedBlockData.createData(blockMaterial));
+                    try {
+                        pm.sendServerPacket(player, packet);
+                    } catch (Exception ignored) {
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Checks if given position resides within mine bounds.
+     */
+    public boolean isInside(BlockPosition pos) {
+        int minX = origin.getBlockX();
+        int minY = origin.getBlockY();
+        int minZ = origin.getBlockZ();
+        return pos.getX() >= minX && pos.getX() < minX + size
+                && pos.getY() >= minY && pos.getY() < minY + height
+                && pos.getZ() >= minZ && pos.getZ() < minZ + size;
+    }
+
+    /**
+     * Handles block breaking by sending air packet and tracking progress.
+     */
+    public void handleBreak(Player player, BlockPosition pos) {
+        if (!brokenBlocks.add(pos)) {
+            return;
+        }
+
+        ProtocolManager pm = protocol();
+        PacketContainer packet = pm.createPacket(PacketType.Play.Server.BLOCK_CHANGE);
+        packet.getBlockPositionModifier().write(0, pos);
+        packet.getBlockData().write(0, WrappedBlockData.createData(Material.AIR));
+        try {
+            pm.sendServerPacket(player, packet);
+        } catch (Exception ignored) {
+        }
+    }
+
+    public double getProgress() {
+        return (double) brokenBlocks.size() / (size * size * height);
+    }
+
+    /**
+     * Resets the mine back to original blocks.
+     */
+    public void reset(Player player) {
+        brokenBlocks.clear();
+        render(player);
+    }
+}

--- a/src/main/java/dev/drawethree/xprison/mines/packet/PacketMineListener.java
+++ b/src/main/java/dev/drawethree/xprison/mines/packet/PacketMineListener.java
@@ -1,0 +1,50 @@
+package dev.drawethree.xprison.mines.packet;
+
+import com.comphenix.protocol.PacketType;
+import com.comphenix.protocol.ProtocolLibrary;
+import com.comphenix.protocol.events.PacketAdapter;
+import com.comphenix.protocol.events.PacketEvent;
+import com.comphenix.protocol.wrappers.BlockPosition;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerJoinEvent;
+import org.bukkit.plugin.Plugin;
+
+/**
+ * Listens for player join and block dig packets to power mines.
+ */
+public class PacketMineListener implements Listener {
+
+    private final PacketMineManager manager;
+
+    public PacketMineListener(PacketMineManager manager) {
+        this.manager = manager;
+        Plugin plugin = manager.getPlugin().getCore();
+        ProtocolLibrary.getProtocolManager().addPacketListener(new PacketAdapter(plugin, PacketType.Play.Client.BLOCK_DIG) {
+            @Override
+            public void onPacketReceiving(PacketEvent event) {
+                Player player = event.getPlayer();
+                PacketMine mine = manager.getMine(player);
+                if (mine == null) {
+                    return;
+                }
+                BlockPosition pos = event.getPacket().getBlockPositionModifier().read(0);
+                if (mine.isInside(pos)) {
+                    mine.handleBreak(player, pos);
+                    if (mine.getProgress() >= 0.90) {
+                        mine.reset(player);
+                    }
+                    event.setCancelled(true);
+                }
+            }
+        });
+        plugin.getServer().getPluginManager().registerEvents(this, plugin);
+    }
+
+    @EventHandler
+    public void onJoin(PlayerJoinEvent event) {
+        Player player = event.getPlayer();
+        manager.getOrCreateMine(player);
+    }
+}

--- a/src/main/java/dev/drawethree/xprison/mines/packet/PacketMineManager.java
+++ b/src/main/java/dev/drawethree/xprison/mines/packet/PacketMineManager.java
@@ -1,0 +1,85 @@
+package dev.drawethree.xprison.mines.packet;
+
+import dev.drawethree.xprison.mines.XPrisonMines;
+import lombok.Getter;
+import org.bukkit.Location;
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.entity.Player;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * Handles creation and management of player mines.
+ */
+public class PacketMineManager {
+
+    @Getter
+    private final XPrisonMines plugin;
+    private final Map<UUID, PacketMine> mines = new HashMap<>();
+    private final Map<Integer, SizeLevel> sizeLevels = new HashMap<>();
+
+    public PacketMineManager(XPrisonMines plugin) {
+        this.plugin = plugin;
+        loadSizeLevels();
+    }
+
+    private void loadSizeLevels() {
+        ConfigurationSection sec = plugin.getConfig().getConfigurationSection("size_levels");
+        if (sec == null) {
+            return;
+        }
+        for (String key : sec.getKeys(false)) {
+            int level = Integer.parseInt(key);
+            int size = sec.getInt(key + ".size");
+            double cost = sec.getDouble(key + ".cost");
+            sizeLevels.put(level, new SizeLevel(level, size, cost));
+        }
+    }
+
+    public PacketMine getMine(Player player) {
+        return mines.get(player.getUniqueId());
+    }
+
+    public PacketMine getOrCreateMine(Player player) {
+        return mines.computeIfAbsent(player.getUniqueId(), uuid -> {
+            SizeLevel level = sizeLevels.getOrDefault(1, new SizeLevel(1, 20, 0));
+            Location origin = player.getLocation().clone().add(-level.getSize() / 2.0, -1, -level.getSize() / 2.0);
+            PacketMine mine = new PacketMine(uuid, origin, level.getSize());
+            mine.render(player);
+            return mine;
+        });
+    }
+
+    public void resetMine(Player player) {
+        PacketMine mine = getMine(player);
+        if (mine != null) {
+            mine.reset(player);
+        }
+    }
+
+    public Map<Integer, SizeLevel> getSizeLevels() {
+        return sizeLevels;
+    }
+
+    public void openMainGUI(Player player) {
+        new PlayerMineGUI(this, player).open();
+    }
+
+    /**
+     * Represents a size level entry.
+     */
+    @Getter
+    public static class SizeLevel {
+        private final int level;
+        private final int size;
+        private final double cost;
+
+        public SizeLevel(int level, int size, double cost) {
+            this.level = level;
+            this.size = size;
+            this.cost = cost;
+        }
+    }
+}

--- a/src/main/java/dev/drawethree/xprison/mines/packet/PlayerMineGUI.java
+++ b/src/main/java/dev/drawethree/xprison/mines/packet/PlayerMineGUI.java
@@ -1,0 +1,53 @@
+package dev.drawethree.xprison.mines.packet;
+
+import com.cryptomorin.xseries.XMaterial;
+import dev.drawethree.xprison.utils.item.ItemStackBuilder;
+import me.lucko.helper.menu.Gui;
+import org.bukkit.entity.Player;
+
+/**
+ * Main GUI for player mines.
+ */
+public class PlayerMineGUI extends Gui {
+
+    private final PacketMineManager manager;
+
+    public PlayerMineGUI(PacketMineManager manager, Player player) {
+        super(player, 6, "Your Mine");
+        this.manager = manager;
+    }
+
+    @Override
+    public void redraw() {
+        for (int i = 0; i < 6 * 9; i++) {
+            this.setItem(i, ItemStackBuilder.of(XMaterial.BLACK_STAINED_GLASS_PANE.parseItem()).name(" ").buildItem().build());
+        }
+
+        this.setItem(10, ItemStackBuilder.of(XMaterial.CHEST.parseItem()).name("&eSize Upgrades").build(() -> {
+            // TODO: open size upgrades GUI
+        }));
+
+        this.setItem(12, ItemStackBuilder.of(XMaterial.GRASS_BLOCK.parseItem()).name("&eBlock Editor").build(() -> {
+            // TODO: open block editor GUI
+        }));
+
+        this.setItem(14, ItemStackBuilder.of(XMaterial.WHITE_WOOL.parseItem()).name("&eBackground Editor").build(() -> {
+            // TODO: open background editor GUI
+        }));
+
+        this.setItem(16, ItemStackBuilder.of(XMaterial.REDSTONE_BLOCK.parseItem()).name("&eReset Mine").build(() -> {
+            manager.resetMine(this.getPlayer());
+            this.redraw();
+        }));
+
+        this.setItem(28, ItemStackBuilder.of(XMaterial.LEVER.parseItem()).name("&eAuto Reset").lore("&7Coming soon...").build(() -> {
+            // toggle auto reset
+        }));
+
+        this.setItem(30, ItemStackBuilder.of(XMaterial.BEACON.parseItem()).name("&eActive Boosters").lore("&7Coming soon...").build(() -> {
+            // boosters placeholder
+        }));
+
+        this.setItem(40, ItemStackBuilder.of(XMaterial.BARRIER.parseItem()).name("&cClose").build(() -> this.close()));
+    }
+}

--- a/src/main/resources/mines.yml
+++ b/src/main/resources/mines.yml
@@ -25,3 +25,35 @@ messages:
   mine_all_reset_success: '&6All mines were reset.'
   mine_all_reset_started: '&6Started reset of all mines.'
   mine_renamed: '&6Mine &e%mine% &6was renamed to &e%new_name%&6.'
+
+size_levels:
+  1:
+    size: 20
+    cost: 0
+  2:
+    size: 30
+    cost: 5000
+  3:
+    size: 50
+    cost: 25000
+  4:
+    size: 80
+    cost: 100000
+  5:
+    size: 120
+    cost: 250000
+  6:
+    size: 150
+    cost: 500000
+  7:
+    size: 170
+    cost: 750000
+  8:
+    size: 190
+    cost: 900000
+  9:
+    size: 195
+    cost: 975000
+  10:
+    size: 200
+    cost: 1000000


### PR DESCRIPTION
## Summary
- add ProtocolLib and repository to build
- introduce packet-based mines rendered client-side
- expose new /mine GUI with basic controls

## Testing
- `mvn -q -e test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:pom:3.3.1... Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_688ea44627548322b3836cc7ec173d9f